### PR TITLE
Merge config on reload

### DIFF
--- a/files/haproxy-systemd.conf
+++ b/files/haproxy-systemd.conf
@@ -1,4 +1,4 @@
 [Service]
 ExecStartPre=
 ExecStartPre=/etc/haproxy/gen-conf.sh
-ExecStartPre=/usr/sbin/haproxy -f ${CONFIG} -c -q
+ExecStartPre=/usr/sbin/haproxy -f ${CONFIG} -c -q $EXTRAOPTS

--- a/files/haproxy-systemd.conf
+++ b/files/haproxy-systemd.conf
@@ -2,3 +2,7 @@
 ExecStartPre=
 ExecStartPre=/etc/haproxy/gen-conf.sh
 ExecStartPre=/usr/sbin/haproxy -f ${CONFIG} -c -q $EXTRAOPTS
+ExecReload=
+ExecReload=/etc/haproxy/gen-conf.sh
+ExecReload=/usr/sbin/haproxy -f ${CONFIG} -c -q $EXTRAOPTS
+ExecReload=/bin/kill -USR2 $MAINPID


### PR DESCRIPTION
Rerun the concatenation of conf.d files during reload

Configuration checking is done by systemd, however this doesn't seem to stop execution when the check is negative...