### PR TITLE
Add option for maximum number of connections

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,6 @@ haproxy_ssl_bind_ciphers: 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES1
 haproxy_ssl_bind_options: 'no-sslv3'
 haproxy_ssl_server_ciphers: 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS'
 haproxy_ssl_server_options: 'no-sslv3'
+haproxy_maxconn: 512
 
 haproxy_debian_release: "{{ ansible_distribution_release }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,5 +3,7 @@ haproxy_ssl_bind_options: 'no-sslv3'
 haproxy_ssl_server_ciphers: 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS'
 haproxy_ssl_server_options: 'no-sslv3'
 haproxy_maxconn: 512
+haproxy_own_file_limit: 25
+haproxy_limit_no_file: "{{ haproxy_maxconn + haproxy_own_file_limit }}"
 
 haproxy_debian_release: "{{ ansible_distribution_release }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
 
   - name: Configure haproxy to use conf.d-style configs
     become: True
-    copy: src=haproxy-systemd.conf dest=/etc/systemd/system/haproxy.service.d/ansible.conf owner=root group=root mode=0644
+    template: src=systemd.service.j2 dest=/etc/systemd/system/haproxy.service.d/ansible.conf owner=root group=root mode=0644
     register: dropindir
 
   - name: reload systemd

--- a/templates/01-defaults.conf.j2
+++ b/templates/01-defaults.conf.j2
@@ -1,3 +1,6 @@
+# Managed by ansible (role: haproxy)
+# DO NOT EDIT!
+
 global
 	log /dev/log	local0 notice
 	log /dev/log	local1 notice
@@ -11,6 +14,8 @@ global
 	# Default SSL material locations
 	ca-base /etc/ssl/certs
 	crt-base /etc/ssl/private
+
+	maxconn {{ haproxy_maxconn }}
 
 	# Default ciphers to use on SSL-enabled listening sockets.
 	# For more information, see ciphers(1SSL). This list is from:

--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -2,7 +2,7 @@
 # DO NOT EDIT!
 
 [Service]
-LimitNOFILE={{ haproxy_maxconn + 10 }}
+LimitNOFILE={{ haproxy_maxconn + 25 }}
 ExecStartPre=
 ExecStartPre=/etc/haproxy/gen-conf.sh
 ExecStartPre=/usr/sbin/haproxy -f ${CONFIG} -c -q $EXTRAOPTS

--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -1,4 +1,8 @@
+# Managed by ansible (role: haproxy)
+# DO NOT EDIT!
+
 [Service]
+LimitNOFILE={{ haproxy_maxconn + 10 }}
 ExecStartPre=
 ExecStartPre=/etc/haproxy/gen-conf.sh
 ExecStartPre=/usr/sbin/haproxy -f ${CONFIG} -c -q $EXTRAOPTS

--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -2,7 +2,7 @@
 # DO NOT EDIT!
 
 [Service]
-LimitNOFILE={{ haproxy_maxconn + 25 }}
+LimitNOFILE={{ haproxy_limit_no_file }}
 ExecStartPre=
 ExecStartPre=/etc/haproxy/gen-conf.sh
 ExecStartPre=/usr/sbin/haproxy -f ${CONFIG} -c -q $EXTRAOPTS


### PR DESCRIPTION
Configure both haproxy and systed limits to allow a high number of
connections. The systemd limit is a bit higher to have some tolerance
for haproxy to open more files than he has open connections