### PR TITLE
Fix loop

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
   - name: Create haproxy directories
     become: True
     file:
-      path: /etc/systemd/system/haproxy.service.d
+      path: "{{ item }}"
       state: directory
     loop:
       - "/etc/systemd/system/haproxy.service.d"


### PR DESCRIPTION
I noticed a small error in the loop, where even though items are specified, they're not used.
This leads to an error in debian buster because the `conf.d` directory will not be created.